### PR TITLE
Fix potential MissingBackpressureException

### DIFF
--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/BleModule.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/BleModule.java
@@ -53,6 +53,7 @@ import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.functions.Func0;
 import rx.functions.Func1;
+import rx.schedulers.Schedulers;
 
 import static com.polidea.multiplatformbleadapter.utils.Constants.BluetoothState;
 
@@ -1605,6 +1606,8 @@ public class BleModule implements BleAdapter {
                         return observable;
                     }
                 })
+                .onBackpressureBuffer()
+                .observeOn(Schedulers.computation())
                 .doOnUnsubscribe(new Action0() {
                     @Override
                     public void call() {


### PR DESCRIPTION
In case notifications/indications come too quickly to be pushed through the bridge to non-native side there will be emitted a `MissingBackpressureException` from RxJava. To mitigate the problem a buffering backpressure strategy is added which should help in most common situations.

Pros:
- No notifications will be discarded

Cons:
- Potential `OutOfMemoryException` in case of prolonged, high speed notifications

Technically backpressure strategy should be exposed on the API level but can be introduced at a later moment.