### PR TITLE
Add deep copying of objects that contain non-final value

### DIFF
--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/BleModule.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/BleModule.java
@@ -844,7 +844,7 @@ public class BleModule implements BleAdapter {
                     public void onNext(byte[] bytes) {
                         descriptor.logValue("Read from", bytes);
                         descriptor.setValue(bytes);
-                        safeExecutor.success(descriptor);
+                        safeExecutor.success(new Descriptor(descriptor));
                     }
                 });
 
@@ -987,7 +987,7 @@ public class BleModule implements BleAdapter {
                     public void onNext(byte[] bytes) {
                         descriptor.logValue("Write to", bytes);
                         descriptor.setValue(bytes);
-                        safeExecutor.success(descriptor);
+                        safeExecutor.success(new Descriptor(descriptor));
                     }
                 });
 
@@ -1492,7 +1492,7 @@ public class BleModule implements BleAdapter {
                     public void onNext(byte[] bytes) {
                         characteristic.logValue("Read from", bytes);
                         characteristic.setValue(bytes);
-                        safeExecutor.success(characteristic);
+                        safeExecutor.success(new Characteristic(characteristic));
                     }
                 });
 
@@ -1564,7 +1564,7 @@ public class BleModule implements BleAdapter {
                     public void onNext(byte[] bytes) {
                         characteristic.logValue("Write to", bytes);
                         characteristic.setValue(bytes);
-                        safeExecutor.success(characteristic);
+                        safeExecutor.success(new Characteristic(characteristic));
                     }
                 });
 
@@ -1631,7 +1631,7 @@ public class BleModule implements BleAdapter {
                     public void onNext(byte[] bytes) {
                         characteristic.logValue("Notification from", bytes);
                         characteristic.setValue(bytes);
-                        onEventCallback.onEvent(characteristic);
+                        onEventCallback.onEvent(new Characteristic(characteristic));
                     }
                 });
 

--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/Characteristic.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/Characteristic.java
@@ -46,6 +46,15 @@ public class Characteristic {
         this.gattCharacteristic = gattCharacteristic;
     }
 
+    public Characteristic(Characteristic other) {
+        id = other.id;
+        serviceID = other.serviceID;
+        serviceUUID = other.serviceUUID;
+        deviceID = other.deviceID;
+        if (other.value != null) value = other.value.clone();
+        gattCharacteristic = other.gattCharacteristic;
+    }
+
     public int getId() {
         return this.id;
     }

--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/Descriptor.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/Descriptor.java
@@ -44,6 +44,18 @@ public class Descriptor {
         this.uuid = uuid;
     }
 
+    public Descriptor(Descriptor other) {
+        characteristicUuid = other.characteristicUuid;
+        characteristicId = other.characteristicId;
+        serviceUuid = other.serviceUuid;
+        serviceId = other.serviceId;
+        deviceId = other.deviceId;
+        descriptor = other.descriptor;
+        id = other.id;
+        uuid = other.uuid;
+        if (other.value != null) value = other.value.clone();
+    }
+
     public int getId() {
         return id;
     }


### PR DESCRIPTION
Issue description:
Value of notification gets malformed/duplicated if notifications are fast enough.

Solution:
By creating a deep copy of objects that carry value, the values are guaranteed to be correct.

See: https://github.com/Polidea/FlutterBleLib/issues/362