### PR TITLE
Fixed BluetoothGattCharacteristic UUID collision

### DIFF
--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/BleModule.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/BleModule.java
@@ -1468,7 +1468,7 @@ public class BleModule implements BleAdapter {
         final SafeExecutor<Characteristic> safeExecutor = new SafeExecutor<>(onSuccessCallback, onErrorCallback);
 
         final Subscription subscription = connection
-                .readCharacteristic(characteristic.getUuid())
+                .readCharacteristic(characteristic.gattCharacteristic)
                 .doOnUnsubscribe(new Action0() {
                     @Override
                     public void call() {
@@ -1540,7 +1540,7 @@ public class BleModule implements BleAdapter {
         final SafeExecutor<Characteristic> safeExecutor = new SafeExecutor<>(onSuccessCallback, onErrorCallback);
 
         final Subscription subscription = connection
-                .writeCharacteristic(characteristic.getUuid(), value)
+                .writeCharacteristic(characteristic.gattCharacteristic, value)
                 .doOnUnsubscribe(new Action0() {
                     @Override
                     public void call() {
@@ -1590,11 +1590,11 @@ public class BleModule implements BleAdapter {
                         ? NotificationSetupMode.QUICK_SETUP
                         : NotificationSetupMode.COMPAT;
                 if (characteristic.isNotifiable()) {
-                    return connection.setupNotification(characteristic.getUuid(), setupMode);
+                    return connection.setupNotification(characteristic.gattCharacteristic, setupMode);
                 }
 
                 if (characteristic.isIndicatable()) {
-                    return connection.setupIndication(characteristic.getUuid(), setupMode);
+                    return connection.setupIndication(characteristic.gattCharacteristic, setupMode);
                 }
 
                 return Observable.error(new CannotMonitorCharacteristicException(characteristic));

--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/Characteristic.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/Characteristic.java
@@ -24,7 +24,7 @@ public class Characteristic {
     final private UUID serviceUUID;
     final private String deviceID;
     private byte[] value;
-    final private BluetoothGattCharacteristic gattCharacteristic;
+    final BluetoothGattCharacteristic gattCharacteristic;
 
     public void setValue(byte[] value) {
         this.value = value;


### PR DESCRIPTION
It may be that a device contain two or more `BluetoothGattCharacteristic` objects that share the same `UUID`. In this case wrong `BluetoothGattCharacteristic` could been chosen if the `UUID` has been passed to `RxAndroidBle`. Fixed by using the `BluetoothGattCharacteristic` object as a parameter and relaxing accesibility of it in `Characteristic` class from `private` to `package protected`.

Related to: https://github.com/Polidea/react-native-ble-plx/issues/674