### PR TITLE
Assign MTU to a device when connecting

### DIFF
--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/BleModule.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/BleModule.java
@@ -459,7 +459,7 @@ public class BleModule implements BleAdapter {
         final RxBleDevice device = rxBleClient.getBleDevice(deviceIdentifier);
 
         if (connectingDevices.removeSubscription(deviceIdentifier) && device != null) {
-            onSuccessCallback.onSuccess(rxBleDeviceToDeviceMapper.map(device));
+            onSuccessCallback.onSuccess(rxBleDeviceToDeviceMapper.map(device, null));
         } else {
             if (device == null) {
                 onErrorCallback.onError(BleErrorUtils.deviceNotFound(deviceIdentifier));
@@ -1245,7 +1245,7 @@ public class BleModule implements BleAdapter {
                     public void call(com.polidea.rxandroidble.scan.ScanResult scanResult) {
                         String deviceId = scanResult.getBleDevice().getMacAddress();
                         if (!discoveredDevices.containsKey(deviceId)) {
-                            discoveredDevices.put(deviceId, rxBleDeviceToDeviceMapper.map(scanResult.getBleDevice()));
+                            discoveredDevices.put(deviceId, rxBleDeviceToDeviceMapper.map(scanResult.getBleDevice(), null));
                         }
                         onEventCallback.onEvent(rxScanResultToScanResultMapper.map(scanResult));
                     }
@@ -1381,7 +1381,7 @@ public class BleModule implements BleAdapter {
 
                     @Override
                     public void onNext(RxBleConnection connection) {
-                        Device localDevice = rxBleDeviceToDeviceMapper.map(device);
+                        Device localDevice = rxBleDeviceToDeviceMapper.map(device, connection);
                         onConnectionStateChangedCallback.onEvent(ConnectionState.CONNECTED);
                         cleanServicesAndCharacteristicsForDevice(localDevice);
                         connectedDevices.put(device.getMacAddress(), localDevice);

--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/utils/mapper/RxBleDeviceToDeviceMapper.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/utils/mapper/RxBleDeviceToDeviceMapper.java
@@ -1,11 +1,19 @@
 package com.polidea.multiplatformbleadapter.utils.mapper;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.polidea.multiplatformbleadapter.Device;
+import com.polidea.rxandroidble.RxBleConnection;
 import com.polidea.rxandroidble.RxBleDevice;
 
 public class RxBleDeviceToDeviceMapper {
 
-    public Device map(RxBleDevice rxDevice) {
-        return new Device(rxDevice.getMacAddress(), rxDevice.getName());
+    public Device map(@NonNull RxBleDevice rxDevice, @Nullable RxBleConnection connection) {
+        Device device = new Device(rxDevice.getMacAddress(), rxDevice.getName());
+        if (connection != null) {
+            device.setMtu(connection.getMtu());
+        }
+        return device;
     }
 }


### PR DESCRIPTION
Before switching to `MultiPlatformBleAdapter`, `react-native-ble-plx` used to extract `mtu` from connection to populate `Device` object.
This PR restores this behaviour.