### PR TITLE
Raw scan record accessor

### DIFF
--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/AdvertisementData.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/AdvertisementData.java
@@ -46,7 +46,7 @@ public class AdvertisementData {
         return solicitedServiceUUIDs;
     }
 
-    public List<UUID> getRawScanRecord() {
+    public byte[] getRawScanRecord() {
         return rawScanRecord;
     }
 

--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/AdvertisementData.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/AdvertisementData.java
@@ -17,6 +17,7 @@ public class AdvertisementData {
     private String localName;
     private Integer txPowerLevel;
     private List<UUID> solicitedServiceUUIDs;
+    private byte[] rawScanRecord;
 
     private static final long BLUETOOTH_BASE_UUID_LSB = 0x800000805F9B34FBL;
     private static final int BLUETOOTH_BASE_UUID_MSB = 0x00001000;
@@ -43,6 +44,10 @@ public class AdvertisementData {
 
     public List<UUID> getSolicitedServiceUUIDs() {
         return solicitedServiceUUIDs;
+    }
+
+    public List<UUID> getRawScanRecord() {
+        return rawScanRecord;
     }
 
     private AdvertisementData() {}

--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/AdvertisementData.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/AdvertisementData.java
@@ -68,6 +68,8 @@ public class AdvertisementData {
 
     public static AdvertisementData parseScanResponseData(byte[] advertisement) {
         AdvertisementData advData = new AdvertisementData();
+        advData.rawScanRecord = advertisement;
+
         ByteBuffer rawData = ByteBuffer.wrap(advertisement).order(ByteOrder.LITTLE_ENDIAN);
         while (rawData.remaining() >= 2) {
             int adLength = rawData.get() & 0xFF;


### PR DESCRIPTION
I added a member which allows for access of raw scan record for Android. There are certain cases in which the parsing method does not provide all of the manufacturer specific advertising data, such as for that of BLE devices which do not properly adhere to the [bluetooth specifications](https://www.bluetooth.com/specifications/specs/) for Android. For those devices, there are exactly 2 bytes which are missing from the parsed scan record.